### PR TITLE
removed document was added in remove trigger event

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -101,7 +101,7 @@ module.exports = exports = function MongooseTrigger(schema, options) {
     if(options.events.remove) {
       let EventName = 'remove' ;
 
-      Emitter({ _id: this._id}, {
+      Emitter(this, {
         eventName: EventName,
         debug: options.debug
       }, emitter);


### PR DESCRIPTION
We can not reach other id's if document has more than one id. Such as foreign reference ids.
`postedBy: {
        type: mongoose.Schema.Types.ObjectId, ref: 'users',
    },`